### PR TITLE
Tala: Added readme.html file and resolving semgrep failure

### DIFF
--- a/readme.html
+++ b/readme.html
@@ -1,0 +1,38 @@
+<!-- File: readme.html
+
+Copyright (c) 2018-2021 Splunk Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software distributed under
+the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied. See the License for the specific language governing permissions
+and limitations under the License.
+
+
+without a valid written license from Splunk Inc. is PROHIBITED. Phantom App imports
+-->
+<p>
+  The app uses HTTP/ HTTPS protocol for communicating with the Tala server. Below are the default ports used by Splunk SOAR.
+  <table>
+      <tr class=plain>
+          <th>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;Service Name</th>
+          <th>Transport Protocol</th>
+          <th>Port</th>
+      </tr>
+      <tr>
+          <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;http</td>
+          <td>tcp</td>
+          <td>80</td>
+      </tr>
+      <tr>
+          <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;https</td>
+          <td>tcp</td>
+          <td>443</td>
+      </tr>
+  </table>
+</p>

--- a/tala_connector.py
+++ b/tala_connector.py
@@ -169,11 +169,11 @@ class TalaConnector(BaseConnector):
 
         url = self._base_url + endpoint
         try:
-            r = requests.post(
+            r = requests.post(  # nosemgrep
                 str(url),
                 json=json,
                 headers={ 'Content-Type': 'application/json' }
-            )   # nosemgrep
+            )
         except Exception as e:
             return action_result.set_status(phantom.APP_ERROR, "{}".format(str(e)))
 


### PR DESCRIPTION
- Adding HTTP and HTTPS Port information as part of the documentation.
- Updating `semgrep` comment for ignoring semgrep test on a specific line.